### PR TITLE
fix: préserver les anciennes routes de production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,46 @@
   publish = "web-build"
 
 [[redirects]]
+  from = "/Accueil"
+  to = "/home"
+  status = 301
+
+[[redirects]]
+  from = "/CalculPertesDeCharge"
+  to = "/calcul-pertes-de-charge"
+  status = 301
+
+[[redirects]]
+  from = "/CalculEtablissement"
+  to = "/calcul-etablissement"
+  status = 301
+
+[[redirects]]
+  from = "/DebitMaxPEI"
+  to = "/capacite-pei"
+  status = 301
+
+[[redirects]]
+  from = "/Relais"
+  to = "/pompage-relais"
+  status = 301
+
+[[redirects]]
+  from = "/GrandsFeux"
+  to = "/liquides-inflammables"
+  status = 301
+
+[[redirects]]
+  from = "/Parametres"
+  to = "/reglages"
+  status = 301
+
+[[redirects]]
+  from = "/ValeursPerso"
+  to = "/valeurs-perso"
+  status = 301
+
+[[redirects]]
   from = "/accueil"
   to = "/home"
   status = 301


### PR DESCRIPTION
## Correctif\n- ajoute les redirections exactes des huit anciennes URL avec leur casse historique\n- conserve les redirections normalisées en minuscules\n\n## Validation\n- npm run release:check\n- 43 tests réussis\n- export statique de 22 routes réussi